### PR TITLE
Add Kubernetes addon configurations and basic test deployment

### DIFF
--- a/k8s-addons/dashboard-admin-user.yaml
+++ b/k8s-addons/dashboard-admin-user.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/k8s-addons/ingress-nginx-values.yaml
+++ b/k8s-addons/ingress-nginx-values.yaml
@@ -1,0 +1,3 @@
+controller:
+  service:
+    type: LoadBalancer

--- a/k8s-addons/metallb-ippool.yaml
+++ b/k8s-addons/metallb-ippool.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: remla-ippool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.56.240-192.168.56.250

--- a/k8s-addons/metallb-l2adv.yaml
+++ b/k8s-addons/metallb-l2adv.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: remla-l2
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - remla-ippool

--- a/k8s-addons/provision.sh
+++ b/k8s-addons/provision.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+echo "[Step 1] Installing MetalLB..."
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml
+
+echo "[Step 2] Waiting for MetalLB pods to be ready..."
+kubectl wait --namespace metallb-system --for=condition=Ready pods --all --timeout=120s
+
+echo "[Step 3] Applying MetalLB IPPool and L2Advertisement..."
+kubectl apply -f metallb-ippool.yaml
+kubectl apply -f metallb-l2adv.yaml
+
+echo "[Step 4] Deploying NGINX Ingress Controller via Helm..."
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+helm install ingress-nginx ingress-nginx/ingress-nginx -f ingress-nginx-values.yaml
+
+echo "[Step 5] Deploying Kubernetes Dashboard..."
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
+kubectl apply -f dashboard-admin-user.yaml
+
+echo "[Step 6] Deploying smoke test sample app..."
+kubectl apply -f test-deployment.yaml
+
+echo "[Step 7] Waiting for all deployments to be ready..."
+kubectl wait --for=condition=available --timeout=120s deployment/smoke-app
+kubectl wait --namespace ingress-nginx --for=condition=Ready pods --all --timeout=120s
+
+echo "[Step 8] Listing services and LoadBalancer IPs..."
+kubectl get svc
+
+echo "[Step 9] Verifying test app is reachable (manual curl recommended if IP is assigned)..."
+echo "Check the EXTERNAL-IP of the 'smoke-app' service above and test with:"
+echo "  curl http://<EXTERNAL-IP>"

--- a/k8s-addons/test-deployment.yaml
+++ b/k8s-addons/test-deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smoke-app
+  template:
+    metadata:
+      labels:
+        app: smoke-app
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smoke-app
+spec:
+  type: LoadBalancer
+  selector:
+    app: smoke-app
+  ports:
+  - port: 80
+    targetPort: 80


### PR DESCRIPTION
This PR adds a set of Kubernetes addon configuration files in the `k8s-addons` folder. These files include:

- MetalLB configuration (`metallb-ippool.yaml`, `metallb-l2adv.yaml`)
- Kubernetes Dashboard admin user setup (`dashboard-admin-user.yaml`)
- Ingress NGINX Helm values (`ingress-nginx-values.yaml`)
- Basic test deployment for validation purposes (`test-deployment.yaml`)
- Provisioning script (`provision.sh`)

The test deployment serves to verify that the cluster and addons are correctly set up.

This change is self-contained and does not impact other parts of the project.
