### PR TITLE
Add configurable prometheus monitoring and alerting for app and model…

### DIFF
--- a/ACTIVITY.md
+++ b/ACTIVITY.md
@@ -2,7 +2,7 @@
 
 **-- Cristian Comendant: --**
 
-Created PR: https://github.com/remla25-team7/operation/pull/1 
+Created PR: https://github.com/remla25-team7/operation/pull/1
 
 Approved PR: https://github.com/remla25-team7/app/pull/2
 
@@ -22,7 +22,7 @@ Created RR: https://github.com/remla25-team7/model-service/pull/2
 Created PR: https://github.com/remla25-team7/model-service/pull/3
 Created PR: https://github.com/remla25-team7/model-service/pull/4#commits-pushed-e37a277
 
-Approved PR: 
+Approved PR:
 
 **-- Seyidali Bulut --**
 
@@ -34,8 +34,7 @@ Approved PR: https://github.com/remla25-team7/model-training/pull/1
 
 Created PR: https://github.com/remla25-team7/model-service/pull/1
 
-Approved PR: 
-
+Approved PR:
 
 # Assignment 2:
 
@@ -43,7 +42,7 @@ Approved PR:
 
 Created PR: https://github.com/remla25-team7/operation/pull/3
 
-Approved PR: https://github.com/remla25-team7/operation/pull/4 
+Approved PR: https://github.com/remla25-team7/operation/pull/4
 
 **-- Andreea Onofrei: --**
 
@@ -53,8 +52,8 @@ Approved PR: https://github.com/remla25-team7/operation/pull/8
 
 **-- Moegiez Bhatti --**
 
-Created PR: https://github.com/remla25-team7/operation/pull/9 
-        AND https://github.com/remla25-team7/operation/pull/10
+Created PR: https://github.com/remla25-team7/operation/pull/9
+AND https://github.com/remla25-team7/operation/pull/10
 
 Approved PR:
 https://github.com/remla25-team7/operation/pull/11
@@ -74,16 +73,15 @@ Created PR: https://github.com/remla25-team7/operation/pull/4
 
 Approved PR: https://github.com/remla25-team7/operation/pull/3
 
-# Assignmenr 3: 
+# Assignmenr 3:
 
 **-- Răzvan Loghin: --**
 
 Created PR: https://github.com/remla25-team7/operation/pull/13
 
-Approved PR: 
+Approved PR:
 
 **-- Seyidali Bulut --**
-
 
 Created PR: https://github.com/remla25-team7/operation/pull/14
 
@@ -94,3 +92,9 @@ Approved PR: https://github.com/remla25-team7/operation/pull/15
 Created PR: https://github.com/remla25-team7/operation/pull/15
 
 Approved PR: https://github.com/remla25-team7/operation/pull/16
+
+**-- Cristian Comendant: --**
+
+Created PR:
+
+Approved PR: https://github.com/remla25-team7/operation/pull/13

--- a/helm/restaurant-sentiment/templates/prometheusrule.yaml
+++ b/helm/restaurant-sentiment/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: sentiment-app-alerts
+  labels:
+    release: prometheus
+    team: restaurant-sentiment
+spec:
+  groups:
+    - name: app.rules
+      rules:
+        - alert: HighRequestRate
+          expr: sum(rate(http_requests_total{job="sentiment-app"}[1m])) > {{ .Values.monitoring.appRequestRateThreshold | default 15 }}
+          for: {{ .Values.monitoring.appRequestRateDuration | default "2m" }}
+          labels:
+            severity: warning
+          annotations:
+            summary: "High request rate detected on sentiment-app"
+            description: "The sentiment-app received more than {{ .Values.monitoring.appRequestRateThreshold | default 15 }} requests per minute for at least {{ .Values.monitoring.appRequestRateDuration | default "2m" }}."
+#
+# This PrometheusRule will trigger an alert if your app receives more than the configured requests per minute for the configured duration.
+{{- end }}

--- a/helm/restaurant-sentiment/templates/service-app.yaml
+++ b/helm/restaurant-sentiment/templates/service-app.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: app
+  name: sentiment-app
+  labels:
+    app: sentiment-app
 spec:
   selector:
     app: app

--- a/helm/restaurant-sentiment/templates/service-model.yaml
+++ b/helm/restaurant-sentiment/templates/service-model.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: model-service
+  name: sentiment-model
+  labels:
+    app: sentiment-model
 spec:
   selector:
     app: model-service

--- a/helm/restaurant-sentiment/templates/servicemonitor.yaml
+++ b/helm/restaurant-sentiment/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sentiment-app-monitor
+  labels:
+    release: prometheus
+    team: restaurant-sentiment
+spec:
+  selector:
+    matchLabels:
+      app: sentiment-app
+  namespaceSelector:
+    any: true
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
+      scheme: http
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sentiment-model-monitor
+  labels:
+    release: prometheus
+    team: restaurant-sentiment
+spec:
+  selector:
+    matchLabels:
+      app: sentiment-model 
+  namespaceSelector:
+    any: true
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
+      scheme: http
+#
+# This ServiceMonitor will let Prometheus discover and scrape metrics from both your app and model-service.
+{{- end }} 

--- a/helm/restaurant-sentiment/values.yaml
+++ b/helm/restaurant-sentiment/values.yaml
@@ -7,3 +7,9 @@ modelService:
   image: ghcr.io/remla25-team7/model-service:latest
   port: 8080
   host: model.local
+
+monitoring:
+  enabled: true
+  scrapeInterval: 15s
+  appRequestRateThreshold: 15
+  appRequestRateDuration: 2m

--- a/join_command.sh
+++ b/join_command.sh
@@ -1,0 +1,1 @@
+kubeadm join 192.168.56.100:6443 --token pkk6tp.gjphfj94xt6f6ffv --discovery-token-ca-cert-hash sha256:72ea86d6dbb1e4a265f73c3d63e2aba1911ae22eb9a29515a5dfc19d61369187 --cri-socket=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
implement Prometheus monitoring and alerting for app and model-service

- Add ServiceMonitor resources for both app and model-service to enable prometheus scraping of /metrics endpoints
- Add prometheusRule for alerting on high request rate, configurable via values.yaml
- Make monitoring configuration (enable/disable, scrape interval, alert thresholds) customizable through values.yaml
- Ensure service definitions have correct labels for ServiceMonitor discovery
