### PR TITLE
 Add Prometheus Metrics, Alerts, and Helm-based Monitoring Setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 APP_SERVICE_IMAGE=ghcr.io/remla25-team7/app
 MODEL_SERVICE_IMAGE=ghcr.io/remla25-team7/model-service
 
-APP_SERVICE_VERSION=release
+APP_SERVICE_VERSION=latest
 MODEL_SERVICE_VERSION=latest
 
 APP_SERVICE_PORT=5001

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ kubeconfig
 Readme.md
 kubeinit.out
 inventory.cfg
+join_command.sh

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This repository serves as the main entry point for the **Sentiment Analysis Syst
 
 ### Related Repositories
 
-- **Model Training**: [github.com/remla25-team7/model-training](https://github.com/remla25-team7/model-training)  
-- **Model Service**: [github.com/remla25-team7/model-service](https://github.com/remla25-team7/model-service)  
-- **Library for Machine Learning (lib-ml)**: [github.com/remla25-team7/lib-ml](https://github.com/remla25-team7/lib-ml)  
-- **Library for Versioning (lib-version)**: [github.com/remla25-team7/lib-version](https://github.com/remla25-team7/lib-version)  
-- **Application Frontend and Service (app)**: [github.com/remla25-team7/app](https://github.com/remla25-team7/app)  
+- **Model Training**: [github.com/remla25-team7/model-training](https://github.com/remla25-team7/model-training)
+- **Model Service**: [github.com/remla25-team7/model-service](https://github.com/remla25-team7/model-service)
+- **Library for Machine Learning (lib-ml)**: [github.com/remla25-team7/lib-ml](https://github.com/remla25-team7/lib-ml)
+- **Library for Versioning (lib-version)**: [github.com/remla25-team7/lib-version](https://github.com/remla25-team7/lib-version)
+- **Application Frontend and Service (app)**: [github.com/remla25-team7/app](https://github.com/remla25-team7/app)
 
 ---
 
@@ -18,12 +18,13 @@ This repository serves as the main entry point for the **Sentiment Analysis Syst
 
 ### Prerequisites
 
-- [Docker](https://www.docker.com/)  
-- [Docker Compose](https://docs.docker.com/compose/)  
+- [Docker](https://www.docker.com/)
+- [Docker Compose](https://docs.docker.com/compose/)
 
 ### Running the Application
 
-1. **Clone this repository**  
+1. **Clone this repository**
+
    ```bash
    git clone https://github.com/remla25-team7/operation.git
    cd operation
@@ -47,8 +48,6 @@ This repository serves as the main entry point for the **Sentiment Analysis Syst
    docker-compose up -d
    ```
 
-
-
 ## Code Structure
 
 | File / Directory                | Purpose                                                                                                          |
@@ -64,33 +63,38 @@ This repository serves as the main entry point for the **Sentiment Analysis Syst
 
 ### Assignment A1
 
-* **Model-Training**
+- **Model-Training**
 
-  * Created the ML training pipeline using a Hugging Face model.
-* **Model-Service**
+  - Created the ML training pipeline using a Hugging Face model.
 
-  * Containerized the ML model with Docker and exposed it via a Flask REST API.
-  * Implemented a GitHub Actions workflow to automatically build and publish the container.
-* **Lib-ML**
+- **Model-Service**
 
-  * Standardized preprocessing in a PyPI package used by both training and the model service.
-* **Lib-Version**
+  - Containerized the ML model with Docker and exposed it via a Flask REST API.
+  - Implemented a GitHub Actions workflow to automatically build and publish the container.
 
-  * Built a version-checker utility for the app service.
-* **App**
+- **Lib-ML**
 
-  * Developed a Dockerized web application using HTML/Bootstrap 5 (frontend) and Flask (backend).
-* **Operation**
+  - Standardized preprocessing in a PyPI package used by both training and the model service.
 
-  * Centralized deployment configurations in this repository, featuring Docker Compose and detailed README instructions.
+- **Lib-Version**
+
+  - Built a version-checker utility for the app service.
+
+- **App**
+
+  - Developed a Dockerized web application using HTML/Bootstrap 5 (frontend) and Flask (backend).
+
+- **Operation**
+
+  - Centralized deployment configurations in this repository, featuring Docker Compose and detailed README instructions.
 
 ### Assignment A2
 
 #### Prerequisites
 
-* **Vagrant** & **VirtualBox** installed
-* **Ansible 2.18+** on host (or use the bundled Vagrant provisioner)
-* Host OS user must be able to edit `/etc/hosts`
+- **Vagrant** & **VirtualBox** installed
+- **Ansible 2.18+** on host (or use the bundled Vagrant provisioner)
+- Host OS user must be able to edit `/etc/hosts`
 
 #### 1. Clone & Spin Up
 
@@ -120,6 +124,12 @@ Open in your browser:
 https://dashboard.local/
 ```
 
+##### 3.1 CTRL port-forwarding
+
+```bash
+kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
+```
+
 #### 4. Log in as Admin
 
 Retrieve your token on the control VM:
@@ -128,7 +138,9 @@ Retrieve your token on the control VM:
 vagrant ssh ctrl
 kubectl -n kubernetes-dashboard create token admin-user
 ```
+
 ### Assignment 3
+
 #### 1. Install Istio (Manual)
 
 1. SSH into the control VM:
@@ -144,7 +156,6 @@ kubectl -n kubernetes-dashboard create token admin-user
    ```
 
    This will install Istio without waiting for confirmation.
-
 
 ## Deploying the App with Helm
 
@@ -170,32 +181,35 @@ modelService:
 
 Find image names using:
 
-* `docker images`
-* GitHub Container Registry
+- `docker images`
+- GitHub Container Registry
 
-### 3. Install the Helm Chart
+### 3. Install Prometheus Operator CRDs and install the Helm Chart
 
 ```bash
+kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 helm install sentiment .
 ```
 
-### 4. Check that it Works
+### 4. Check that it Works and port-forward the app-service
 
 ```bash
 kubectl get pods
 kubectl get svc
 kubectl get ingress
+kubectl port-forward svc/sentiment-app 5001:5001
 ```
 
 You should see:
 
-* `app` and `model-service` pods in `Running` status
-* `app.local` and `model.local` routes via Ingress
+- `app` and `model-service` pods in `Running` status
+- `app.local` and `model.local` routes via Ingress
 
 ### 5. Test in Browser or Curl
 
-* App UI: [http://app.local](http://app.local)
-* Model Endpoint:
+- App UI: [http://app.local](http://app.local)
+- Model Endpoint:
 
   ```bash
   curl -X POST http://model.local/predict \
@@ -221,9 +235,9 @@ prometheus_client   # TODO: expose Prometheus metrics from Flask apps
 
 ## Assignment 3 To-Dos
 
-* [ ] Add `/metrics` endpoint to both app and model-service using `prometheus_client`
-* [ ] Deploy Prometheus via Helm or K8s manifests
-* [ ] Create a `ServiceMonitor` to scrape the metrics
-* [ ] Deploy Grafana via Helm
-* [ ] Create and load a custom Grafana dashboard
-* [ ] Optional: Configure AlertManager with Prometheus rules
+- [ ] Add `/metrics` endpoint to both app and model-service using `prometheus_client`
+- [ ] Deploy Prometheus via Helm or K8s manifests
+- [ ] Create a `ServiceMonitor` to scrape the metrics
+- [ ] Deploy Grafana via Helm
+- [ ] Create and load a custom Grafana dashboard
+- [ ] Optional: Configure AlertManager with Prometheus rules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - app-logs:/var/log/app
     restart: always
     depends_on:
-     - model-service
+      - model-service
 
   model-service:
     image: ${MODEL_SERVICE_IMAGE}:${MODEL_SERVICE_VERSION}
@@ -27,7 +27,6 @@ services:
 volumes:
   app-logs:
   model-cache:
-
 #secrets:
 #  model-credentials:
 #    file: ./secrets/model_credentials.txt

--- a/helm/restaurant-sentiment/templates/configmap.yaml
+++ b/helm/restaurant-sentiment/templates/configmap.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: env-config
 data:
-  MODEL_SERVICE_URL: "http://model-service:8080/predict"
+  MODEL_SERVICE_URL: "http://sentiment-model:8080"

--- a/helm/restaurant-sentiment/templates/deployment-app.yaml
+++ b/helm/restaurant-sentiment/templates/deployment-app.yaml
@@ -2,19 +2,22 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: app
+  labels:
+    app: sentiment-app
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: app
+      app: sentiment-app
   template:
     metadata:
       labels:
-        app: app
+        app: sentiment-app
     spec:
       containers:
         - name: app
           image: {{ .Values.app.image }}
+          imagePullPolicy: {{ .Values.app.imagePullPolicy | default "IfNotPresent" }}
           ports:
             - containerPort: {{ .Values.app.port }}
           envFrom:

--- a/helm/restaurant-sentiment/templates/prometheusrule.yaml
+++ b/helm/restaurant-sentiment/templates/prometheusrule.yaml
@@ -1,23 +1,23 @@
-{{- if .Values.monitoring.enabled }}
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: sentiment-app-alerts
-  labels:
-    release: prometheus
-    team: restaurant-sentiment
-spec:
-  groups:
-    - name: app.rules
-      rules:
-        - alert: HighRequestRate
-          expr: sum(rate(http_requests_total{job="sentiment-app"}[1m])) > {{ .Values.monitoring.appRequestRateThreshold | default 15 }}
-          for: {{ .Values.monitoring.appRequestRateDuration | default "2m" }}
-          labels:
-            severity: warning
-          annotations:
-            summary: "High request rate detected on sentiment-app"
-            description: "The sentiment-app received more than {{ .Values.monitoring.appRequestRateThreshold | default 15 }} requests per minute for at least {{ .Values.monitoring.appRequestRateDuration | default "2m" }}."
-#
-# This PrometheusRule will trigger an alert if your app receives more than the configured requests per minute for the configured duration.
-{{- end }}
+# {{- if .Values.monitoring.enabled }}
+# apiVersion: monitoring.coreos.com/v1
+# kind: PrometheusRule
+# metadata:
+#   name: sentiment-app-alerts
+#   labels:
+#     release: prometheus
+#     team: restaurant-sentiment
+# spec:
+#   groups:
+#     - name: app.rules
+#       rules:
+#         - alert: HighRequestRate
+#           expr: sum(rate(http_requests_total{job="sentiment-app"}[1m])) > {{ .Values.monitoring.appRequestRateThreshold | default 15 }}
+#           for: {{ .Values.monitoring.appRequestRateDuration | default "2m" }}
+#           labels:
+#             severity: warning
+#           annotations:
+#             summary: "High request rate detected on sentiment-app"
+#             description: "The sentiment-app received more than {{ .Values.monitoring.appRequestRateThreshold | default 15 }} requests per minute for at least {{ .Values.monitoring.appRequestRateDuration | default "2m" }}."
+# #
+# # This PrometheusRule will trigger an alert if app receives more than the configured requests per minute for the configured duration.
+# {{- end }}

--- a/helm/restaurant-sentiment/templates/prometheusrule.yaml
+++ b/helm/restaurant-sentiment/templates/prometheusrule.yaml
@@ -1,23 +1,17 @@
-# {{- if .Values.monitoring.enabled }}
-# apiVersion: monitoring.coreos.com/v1
-# kind: PrometheusRule
-# metadata:
-#   name: sentiment-app-alerts
-#   labels:
-#     release: prometheus
-#     team: restaurant-sentiment
-# spec:
-#   groups:
-#     - name: app.rules
-#       rules:
-#         - alert: HighRequestRate
-#           expr: sum(rate(http_requests_total{job="sentiment-app"}[1m])) > {{ .Values.monitoring.appRequestRateThreshold | default 15 }}
-#           for: {{ .Values.monitoring.appRequestRateDuration | default "2m" }}
-#           labels:
-#             severity: warning
-#           annotations:
-#             summary: "High request rate detected on sentiment-app"
-#             description: "The sentiment-app received more than {{ .Values.monitoring.appRequestRateThreshold | default 15 }} requests per minute for at least {{ .Values.monitoring.appRequestRateDuration | default "2m" }}."
-# #
-# # This PrometheusRule will trigger an alert if app receives more than the configured requests per minute for the configured duration.
-# {{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: sentiment-app-alerts
+  labels:
+    release: prometheus
+spec:
+  groups:
+  - name: app.rules
+    rules:
+    - alert: HighRequestRate
+      expr: rate(sentiment_app_requests_total[1m]) > 15
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        summary: "High request rate detected"

--- a/helm/restaurant-sentiment/templates/service-app.yaml
+++ b/helm/restaurant-sentiment/templates/service-app.yaml
@@ -6,8 +6,9 @@ metadata:
     app: sentiment-app
 spec:
   selector:
-    app: app
+    app: sentiment-app
   ports:
-    - port: {{ .Values.app.port }}
+    - name: http
+      port: {{ .Values.app.port }}
       targetPort: {{ .Values.app.port }}
   type: ClusterIP

--- a/helm/restaurant-sentiment/templates/service-model.yaml
+++ b/helm/restaurant-sentiment/templates/service-model.yaml
@@ -8,6 +8,7 @@ spec:
   selector:
     app: model-service
   ports:
-    - port: {{ .Values.modelService.port }}
+    - name: http
+      port: {{ .Values.modelService.port }}
       targetPort: {{ .Values.modelService.port }}
   type: ClusterIP

--- a/helm/restaurant-sentiment/templates/servicemonitor.yaml
+++ b/helm/restaurant-sentiment/templates/servicemonitor.yaml
@@ -1,41 +1,41 @@
-{{- if .Values.monitoring.enabled }}
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: sentiment-app-monitor
-  labels:
-    release: prometheus
-    team: restaurant-sentiment
-spec:
-  selector:
-    matchLabels:
-      app: sentiment-app
-  namespaceSelector:
-    any: true
-  endpoints:
-    - port: http
-      path: /metrics
-      interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
-      scheme: http
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: sentiment-model-monitor
-  labels:
-    release: prometheus
-    team: restaurant-sentiment
-spec:
-  selector:
-    matchLabels:
-      app: sentiment-model 
-  namespaceSelector:
-    any: true
-  endpoints:
-    - port: http
-      path: /metrics
-      interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
-      scheme: http
-#
-# This ServiceMonitor will let Prometheus discover and scrape metrics from both your app and model-service.
-{{- end }} 
+# {{- if .Values.monitoring.enabled }}
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: sentiment-app-monitor
+#   labels:
+#     release: prometheus
+#     team: restaurant-sentiment
+# spec:
+#   selector:
+#     matchLabels:
+#       app: sentiment-app
+#   namespaceSelector:
+#     any: true
+#   endpoints:
+#     - port: http
+#       path: /metrics
+#       interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
+#       scheme: http
+# ---
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: sentiment-model-monitor
+#   labels:
+#     release: prometheus
+#     team: restaurant-sentiment
+# spec:
+#   selector:
+#     matchLabels:
+#       app: sentiment-model 
+#   namespaceSelector:
+#     any: true
+#   endpoints:
+#     - port: http
+#       path: /metrics
+#       interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
+#       scheme: http
+# #
+# # This ServiceMonitor will let Prometheus discover and scrape metrics from both app and model-service.
+# {{- end }} 

--- a/helm/restaurant-sentiment/templates/servicemonitor.yaml
+++ b/helm/restaurant-sentiment/templates/servicemonitor.yaml
@@ -1,41 +1,39 @@
-# {{- if .Values.monitoring.enabled }}
-# apiVersion: monitoring.coreos.com/v1
-# kind: ServiceMonitor
-# metadata:
-#   name: sentiment-app-monitor
-#   labels:
-#     release: prometheus
-#     team: restaurant-sentiment
-# spec:
-#   selector:
-#     matchLabels:
-#       app: sentiment-app
-#   namespaceSelector:
-#     any: true
-#   endpoints:
-#     - port: http
-#       path: /metrics
-#       interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
-#       scheme: http
-# ---
-# apiVersion: monitoring.coreos.com/v1
-# kind: ServiceMonitor
-# metadata:
-#   name: sentiment-model-monitor
-#   labels:
-#     release: prometheus
-#     team: restaurant-sentiment
-# spec:
-#   selector:
-#     matchLabels:
-#       app: sentiment-model 
-#   namespaceSelector:
-#     any: true
-#   endpoints:
-#     - port: http
-#       path: /metrics
-#       interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
-#       scheme: http
-# #
-# # This ServiceMonitor will let Prometheus discover and scrape metrics from both app and model-service.
-# {{- end }} 
+{{- if .Values.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sentiment-app-monitor
+  labels:
+    release: prometheus
+    team: restaurant-sentiment
+spec:
+  selector:
+    matchLabels:
+      app: sentiment-app
+  namespaceSelector:
+    any: true
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
+      scheme: http
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sentiment-model-monitor
+  labels:
+    release: prometheus
+    team: restaurant-sentiment
+spec:
+  selector:
+    matchLabels:
+      app: sentiment-model
+  namespaceSelector:
+    any: true
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.monitoring.scrapeInterval | default "15s" }}
+      scheme: http
+{{- end }}

--- a/helm/restaurant-sentiment/values.yaml
+++ b/helm/restaurant-sentiment/values.yaml
@@ -1,10 +1,13 @@
 app:
-  image: ghcr.io/remla25-team7/app:release
+  image: ghcr.io/remla25-team7/app:latest
+  imagePullPolicy: Always
   port: 5001
   host: app.local
+  
 
 modelService:
   image: ghcr.io/remla25-team7/model-service:latest
+  imagePullPolicy: Always
   port: 8080
   host: model.local
 

--- a/helm/restaurant-sentiment/values.yaml
+++ b/helm/restaurant-sentiment/values.yaml
@@ -1,5 +1,5 @@
 app:
-  image: ghcr.io/remla25-team7/app:latest
+  image: ghcr.io/remla25-team7/app:release
   port: 5001
   host: app.local
 

--- a/join_command.sh
+++ b/join_command.sh
@@ -1,1 +1,1 @@
-kubeadm join 192.168.56.100:6443 --token 4gv3te.kswiclkyjevefcaq --discovery-token-ca-cert-hash sha256:b4f3fc552776fcba111509f38869dd0815cd49c50ef04c71117bc0cfb7efd0b0 --cri-socket=unix:///run/containerd/containerd.sock
+kubeadm join 192.168.56.100:6443 --token ld1wvo.9hezwnbqbbfy3i22 --discovery-token-ca-cert-hash sha256:9c9f7c2b4ca64a1f6eecb268647aa1771955dcd618e03e66468c2322010f9ab4 --cri-socket=unix:///run/containerd/containerd.sock

--- a/join_command.sh
+++ b/join_command.sh
@@ -1,1 +1,1 @@
-kubeadm join 192.168.56.100:6443 --token pkk6tp.gjphfj94xt6f6ffv --discovery-token-ca-cert-hash sha256:72ea86d6dbb1e4a265f73c3d63e2aba1911ae22eb9a29515a5dfc19d61369187 --cri-socket=unix:///run/containerd/containerd.sock
+kubeadm join 192.168.56.100:6443 --token 4gv3te.kswiclkyjevefcaq --discovery-token-ca-cert-hash sha256:b4f3fc552776fcba111509f38869dd0815cd49c50ef04c71117bc0cfb7efd0b0 --cri-socket=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
This PR introduces end-to-end support for monitoring the sentiment app using Prometheus, and Helm. It includes:

Prometheus scraping and service discovery configuration

Alerting via Alertmanager on Prometheus web-browser (email alerts - still needs to be included)

Fixed helm installation and deployment instructions
