### PR TITLE
Add Prometheus Alerting with Email Notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,15 +119,21 @@ nano ~/.bashrc
 ```
 
 Copy the full path of the file named kubeconfig in this repository.
-Then paste this line at the end of your .bashrc/.zshrc: export KUBECONFIG=path/to/your/operation/kubeconfig
+Then paste this line at the end of your .bashrc/.zshrc:
+
+```bash
+export KUBECONFIG=path/to/your/operation/kubeconfig
+```
 
 #### 3. Obtain access token
 
+```bash
 kubectl -n kubernetes-dashboard create token admin-user
+```
 
 ##### 3.1 Kubernetes Dashboard port-forwarding
 
-Run the Kubernetes Dashboard and paste the token in the browser to login.
+Run the Kubernetes Dashboard and paste the token in the browser to login. https://localhost:8443
 
 ```bash
 kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy 8443:443
@@ -151,11 +157,9 @@ helm install prometheus prometheus-community/kube-prometheus-stack --namespace m
 cd helm/restaurant-sentiment
 ```
 
-### 3. Install Prometheus Operator CRDs and install the Helm Chart
+### 3. Install the Helm Chart
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml && \
-kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml && \
 helm install sentiment .
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This repository serves as the main entry point for the **Sentiment Analysis Syst
    cd operation
    ```
 
-2. **Create the `secrets` folder** (if it doesn’t exist)
+2. **Create the `secrets` folder** (if it doesn't exist)
 
    ```bash
    mkdir -p secrets
@@ -146,8 +146,8 @@ kubectl -n kubernetes-dashboard port-forward svc/kubernetes-dashboard-kong-proxy
 To install the Prometheus kube-prometheus-stack chart from the `prometheus-community` repository, run the following command:
 
 ```bash
-helm repo add prometheus-community https://prometheus-community.github.io/helm-charts && \
-helm repo update && \
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
 helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace
 ```
 
@@ -174,26 +174,42 @@ kubectl port-forward svc/sentiment-app 5001:5001
 
 ---
 
-### 6. Access Prometheus UI locally
+### 6. Access Prometheus UI
 
 ```bash
 kubectl port-forward -n monitoring svc/prometheus-kube-prometheus-prometheus 9090:9090
 ```
 
-You can also test Prometheus alert running this command:
+Open [http://localhost:9090](http://localhost:9090) in your browser.
+
+### 7. Enable Email Alerts
+
+1. Edit `values.yaml` and set your email and SMTP details under `.Values.alertmanager.email`.
+2. If using Gmail with 2FA, create an [App Password](https://support.google.com/accounts/answer/185833?hl=en).
+3. Create the SMTP password secret:
+
+```bash
+   kubectl create secret generic kube-prometheus-stack-alertmanager-secret --from-literal=smtpPassword='your-app-password' -n monitoring
+   kubectl delete pod alertmanager-prometheus-kube-prometheus-alertmanager -n monitoring
+   cd helm/restaurant-sentiment && helm upgrade sentiment .
+```
+
+### 8. Test Alerts
+
+Generate traffic to trigger alerts:
 
 ```bash
 while true; do curl -s http://localhost:5001/ > /dev/null; done
 ```
 
-### 7. Debuging
+### 9. Debugging
 
-If a new image is pulled and you want to rerun the helm run these commands:
+If you update your app image or Helm chart and want to redeploy:
 
 ```bash
 kubectl rollout restart deployment app
 cd helm/restaurant-sentiment
-kubectl helm upgrade sentiment .
+helm upgrade sentiment .
 ```
 
 ---

--- a/helm/restaurant-sentiment/templates/alertmanager.yaml
+++ b/helm/restaurant-sentiment/templates/alertmanager.yaml
@@ -1,21 +1,23 @@
-apiVersion: monitoring.coreos.com/v1
+{{- if .Values.alertmanager.enabled }}
+apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
   name: alertmanager-email-config
   namespace: monitoring
 spec:
-  global:
-    smtp_smarthost: 'smtp.gmail.com:587'
-    smtp_from: 'cristiancomend@gmail.com'
-    smtp_auth_username: 'cristiancomend@gmail.com'
-    smtp_auth_password_file: /etc/alertmanager/secrets/smtp_auth_password
-
   route:
     receiver: email-alert
 
   receivers:
-  - name: email-alert
-    emailConfigs:
-    - to: 'cristiancomend@tudelft.nl'
-      sendResolved: true
-
+    - name: email-alert
+      emailConfigs:
+        - to: {{ .Values.alertmanager.email.to | quote }}
+          from: {{ .Values.alertmanager.email.from | quote }}
+          smarthost: {{ .Values.alertmanager.email.smarthost | quote }}
+          authUsername: {{ .Values.alertmanager.email.authUsername | quote }}
+          authPassword:
+            name: {{ .Values.alertmanager.fullname }}-alertmanager-secret
+            key: smtpPassword
+          requireTLS: {{ .Values.alertmanager.email.requireTLS }}
+          sendResolved: true
+{{- end }}

--- a/helm/restaurant-sentiment/templates/alertmanager.yaml
+++ b/helm/restaurant-sentiment/templates/alertmanager.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: AlertmanagerConfig
+metadata:
+  name: alertmanager-email-config
+  namespace: monitoring
+spec:
+  global:
+    smtp_smarthost: 'smtp.gmail.com:587'
+    smtp_from: 'cristiancomend@gmail.com'
+    smtp_auth_username: 'cristiancomend@gmail.com'
+    smtp_auth_password_file: /etc/alertmanager/secrets/smtp_auth_password
+
+  route:
+    receiver: email-alert
+
+  receivers:
+  - name: email-alert
+    emailConfigs:
+    - to: 'cristiancomend@tudelft.nl'
+      sendResolved: true
+

--- a/helm/restaurant-sentiment/templates/crds-prometheus.yaml
+++ b/helm/restaurant-sentiment/templates/crds-prometheus.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: install-prometheus-crds
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    spec:
+      containers:
+      - name: crd-installer
+        image: bitnami/kubectl:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml &&
+          kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+      restartPolicy: OnFailure

--- a/helm/restaurant-sentiment/values.yaml
+++ b/helm/restaurant-sentiment/values.yaml
@@ -16,3 +16,14 @@ monitoring:
   scrapeInterval: 15s
   appRequestRateThreshold: 15
   appRequestRateDuration: 2m
+
+# AlertManager configuration for email alerts
+alertmanager:
+  enabled: true
+  fullname: kube-prometheus-stack
+  email:
+    to: 'to-mail@gmail.com'
+    from: 'from-mail@gmail.com'
+    smarthost: 'smtp.gmail.com:587'
+    authUsername: 'from-mail@gmail.com'
+    requireTLS: true

--- a/join_command.sh
+++ b/join_command.sh
@@ -1,1 +1,1 @@
-kubeadm join 192.168.56.100:6443 --token 6guxdi.slc426m0i4ycoenr --discovery-token-ca-cert-hash sha256:5e9d912b30ec971507fce8d0be72965d1e87d76bcac5bd7866d8a36efbd6896e --cri-socket=unix:///run/containerd/containerd.sock
+kubeadm join 192.168.56.100:6443 --token 0anbqt.vo26l4kmf5tidu0b --discovery-token-ca-cert-hash sha256:4d84ccccff4b2ae3e97106583d84f2859abad41fa28da167ade378687bd18d56 --cri-socket=unix:///run/containerd/containerd.sock

--- a/join_command.sh
+++ b/join_command.sh
@@ -1,1 +1,1 @@
-kubeadm join 192.168.56.100:6443 --token ld1wvo.9hezwnbqbbfy3i22 --discovery-token-ca-cert-hash sha256:9c9f7c2b4ca64a1f6eecb268647aa1771955dcd618e03e66468c2322010f9ab4 --cri-socket=unix:///run/containerd/containerd.sock
+kubeadm join 192.168.56.100:6443 --token 6guxdi.slc426m0i4ycoenr --discovery-token-ca-cert-hash sha256:5e9d912b30ec971507fce8d0be72965d1e87d76bcac5bd7866d8a36efbd6896e --cri-socket=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
Summary
This PR implements email alerting for Prometheus using Alertmanager. Now, when a defined alert (such as high request rate) is triggered, an email notification will be sent to the configured address.

Key Changes
Alertmanager Email Integration:
Configured Alertmanager to send email notifications using SMTP.
Email credentials and SMTP password are securely managed via a Kubernetes Secret.
Instructions for setting up Gmail App Passwords and creating the secret are included in the README.
