### PR TITLE
Add only one service to be exposed to the host and add secret

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 APP_SERVICE_IMAGE=ghcr.io/remla25-team7/app
 MODEL_SERVICE_IMAGE=ghcr.io/remla25-team7/model-service
 
-APP_SERVICE_VERSION=latest
+APP_SERVICE=latest
 MODEL_SERVICE_VERSION=latest
 
 APP_SERVICE_PORT=5001

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-secrets/*
 kubeconfig
 .vagrant
 Readme.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
 services:
   app:
-    image: ${APP_SERVICE_IMAGE}:${APP_SERVICE_VERSION}
+    image: ${APP_SERVICE_IMAGE}:${APP_SERVICE}
+    # this is the only service exposed to the host.
     ports:
       - "${APP_SERVICE_PORT}:${APP_SERVICE_PORT}"
     environment:
+      # communication happens over Docker's internal network using the service name.
       - MODEL_SERVICE_URL=http://model-service:${MODEL_SERVICE_PORT}
-      - APP_VERSION=${APP_SERVICE_VERSION}
+      - APP_SERVICE=${APP_SERVICE}
     env_file:
       - .env
     volumes:
@@ -13,20 +15,22 @@ services:
     restart: always
     depends_on:
       - model-service
+    secrets:
+      - model_credentials
 
   model-service:
     image: ${MODEL_SERVICE_IMAGE}:${MODEL_SERVICE_VERSION}
-    ports:
-      - "${MODEL_SERVICE_PORT}:${MODEL_SERVICE_PORT}"
     env_file:
       - .env
     volumes:
       - model-cache:/model-cache
     restart: always
+    secrets:
+      - model_credentials
 
 volumes:
   app-logs:
   model-cache:
-#secrets:
-#  model-credentials:
-#    file: ./secrets/model_credentials.txt
+secrets:
+  model_credentials:
+    file: ./secrets/model_credentials.txt

--- a/secrets/model_credentials.txt
+++ b/secrets/model_credentials.txt
@@ -1,0 +1,1 @@
+thisIsTheSecret


### PR DESCRIPTION
This PR corrects a variable name in docker-compose.yml. The app service was incorrectly using ${APP_VERSION} for its image tag instead of ${APP_SERVICE_VERSION}.

From now on communication happens over Docker's internal network using the service name.

Secret key was added
