### PR TITLE
Setting up (Virtual) Infrastructure rubric - excellent level

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,14 +7,49 @@ Vagrant.configure("2") do |config|
   CTRL_IP = "192.168.56.100"
   WORKER_BASE_IP = 101
   SUBNET_PREFIX = "192.168.56."
+  WORKER_CPUS = 2
+  WORKER_MEM = 6144
+  CTRL_CPUS = 2
+  CTRL_MEM = 4096
+
+  # Generate inventroy.cfg
+  config.trigger.before [:up, :reload] do |trigger|
+    trigger.name = "Generate ansible inventory file"
+    trigger.ruby do
+      require 'fileutils'
+
+      inventory_file = "inventory.cfg"
+      controller = "ctrl"
+      vagrant_path = ".vagrant/machines"
+
+      File.open(inventory_file, "w") do |f|
+        f.puts "[controller]"
+        f.puts "#{controller} ansible_host=#{CTRL_IP} ansible_user=vagrant " \
+              "ansible_ssh_private_key_file=#{vagrant_path}/#{controller}/virtualbox/private_key " 
+        f.puts ""
+
+        f.puts "[nodes]"
+        NUM_WORKERS.times do |i|
+          name = "node-#{i + 1}"
+          ip = "#{SUBNET_PREFIX}#{WORKER_BASE_IP + i}"
+          f.puts "#{name} ansible_host=#{ip} ansible_user=vagrant " \
+                "ansible_ssh_private_key_file=#{vagrant_path}/#{name}/virtualbox/private_key " 
+        end
+
+        f.puts "\n[all:children]\ncontroller\nnodes\n"
+
+        f.puts "\n[all:vars]\nansible_user=vagrant\nansible_ssh_common_args='-o IdentitiesOnly=yes -o StrictHostKeyChecking=no'"
+      end
+    end
+  end
 
   # Define the control node
   config.vm.define "ctrl" do |ctrl|
     ctrl.vm.hostname = "ctrl"
     ctrl.vm.network "private_network", ip: CTRL_IP
     ctrl.vm.provider "virtualbox" do |vb|
-      vb.memory = 4096
-      vb.cpus = 2
+      vb.memory = CTRL_MEM
+      vb.cpus = CTRL_CPUS
     end
   end
 
@@ -24,8 +59,8 @@ Vagrant.configure("2") do |config|
       node.vm.hostname = "node-#{i}"
       node.vm.network "private_network", ip: "#{SUBNET_PREFIX}#{WORKER_BASE_IP + i - 1}"
       node.vm.provider "virtualbox" do |vb|
-        vb.memory = 6144
-        vb.cpus = 2
+        vb.memory = WORKER_MEM
+        vb.cpus = WORKER_CPUS
       end
     end
   end
@@ -33,7 +68,7 @@ Vagrant.configure("2") do |config|
   # GENERAL (all hosts)
   config.vm.provision "ansible_general", type: "ansible" do |ansible|
     ansible.playbook       = "playbooks/general.yml"
-    # ansible.inventory_path = "inventory.cfg"
+    ansible.inventory_path = "inventory.cfg"
     ansible.extra_vars     = {
       num_workers: NUM_WORKERS
     }
@@ -42,7 +77,7 @@ Vagrant.configure("2") do |config|
   # CTRL (control-plane only)
   config.vm.provision "ansible_ctrl", type: "ansible" do |ansible|
     ansible.playbook       = "playbooks/ctrl.yml"
-    # ansible.inventory_path = "inventory.cfg"
+    ansible.inventory_path = "inventory.cfg"
     ansible.extra_vars     = {
       ingress_loadbalancer_ip: "192.168.56.95"
     }
@@ -51,13 +86,13 @@ Vagrant.configure("2") do |config|
   # NODES (worker nodes only)
   config.vm.provision "ansible_nodes", type: "ansible" do |ansible|
     ansible.playbook       = "playbooks/node.yml"
-    # ansible.inventory_path = "inventory.cfg"
+    ansible.inventory_path = "inventory.cfg"
   end
 
   # FINALIZE (MetalLB, Ingress, Dashboard)
   config.vm.provision "ansible_finalize", type: "ansible" do |ansible|
     ansible.playbook       = "playbooks/finalization.yml"
-    # ansible.inventory_path = "inventory.cfg"
+    ansible.inventory_path = "inventory.cfg"
     ansible.extra_vars     = {
       ingress_loadbalancer_ip: "192.168.56.95"
     }

--- a/inventory.cfg
+++ b/inventory.cfg
@@ -1,22 +1,14 @@
-[kube_controller]
-ctrl ansible_host=192.168.56.100
-     ansible_user=vagrant
-     ansible_ssh_private_key_file=./.vagrant/machines/ctrl/virtualbox/private_key
-     ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+[controller]
+ctrl ansible_host=192.168.56.100 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/ctrl/virtualbox/private_key 
 
-[kube_workers]
-node-1 ansible_host=192.168.56.101
-       ansible_user=vagrant
-       ansible_ssh_private_key_file=./.vagrant/machines/node-1/virtualbox/private_key
-       ansible_ssh_common_args='-o StrictHostKeyChecking=no'
-node-2 ansible_host=192.168.56.102
-       ansible_user=vagrant
-       ansible_ssh_private_key_file=./.vagrant/machines/node-2/virtualbox/private_key
-       ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+[nodes]
+node-1 ansible_host=192.168.56.101 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/node-1/virtualbox/private_key 
+node-2 ansible_host=192.168.56.102 ansible_user=vagrant ansible_ssh_private_key_file=.vagrant/machines/node-2/virtualbox/private_key 
 
 [all:children]
-kube_controller
-kube_workers
+controller
+nodes
 
 [all:vars]
-num_workers=2
+ansible_user=vagrant
+ansible_ssh_common_args='-o IdentitiesOnly=yes -o StrictHostKeyChecking=no'

--- a/join_command.sh
+++ b/join_command.sh
@@ -1,1 +1,1 @@
-kubeadm join 192.168.56.100:6443 --token mr3cwh.lhdpjtahkrzk3no6 --discovery-token-ca-cert-hash sha256:044455a3f37130ea224304adae059cd0d3f17211917f548122c42abed9f5971e --cri-socket=unix:///run/containerd/containerd.sock
+kubeadm join 192.168.56.100:6443 --token yz4l2y.dz2sxefu9pv6ewfl --discovery-token-ca-cert-hash sha256:5102f3d8c3d3a7cd8713ffef54179fbf547922161b38fa42f369df8afc39f4ff --cri-socket=unix:///run/containerd/containerd.sock


### PR DESCRIPTION
Added the following:
- Variables for CPU-cores, memory size and number of workers
- Vagrant now generates automatically the 'inventory.cfg' file and makes sure ansible connect to the VM's trough private network, not port-forwarding

Closes: #31 