### PR TITLE
Add Istio VirtualService for model-service (A5 traffic)

### DIFF
--- a/helm/restaurant-sentiment/templates/model-service-virtualservice.yaml
+++ b/helm/restaurant-sentiment/templates/model-service-virtualservice.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: model-service
+spec:
+  hosts:
+    - model-service
+  http:
+    - match:
+        - headers:
+            x-user-id:
+              exact: "test-user"  # For sticky session simulation
+      route:
+        - destination:
+            host: model-service
+            subset: v2
+          weight: 100
+    - route:
+        - destination:
+            host: model-service
+            subset: v1
+          weight: 90
+        - destination:
+            host: model-service
+            subset: v2
+          weight: 10


### PR DESCRIPTION
This PR adds the Istio `VirtualService` definition to enable a 90/10 traffic split between `model-service` v1 and v2 with sticky routing for user experimentation (A5).

This fulfills the A5 requirement for traffic management using Istio in a service mesh environment.