### PR TITLE
Add Istio VirtualService and DestinationRule for model-service (A5)

### DIFF
--- a/helm/restaurant-sentiment/templates/model-service-destinationrule.yaml
+++ b/helm/restaurant-sentiment/templates/model-service-destinationrule.yaml
@@ -2,9 +2,9 @@
 apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
-  name: {{ include "fullname" . }}-model-service
+  name: model-service
 spec:
-  host: {{ include "fullname" . }}-model-service
+  host: model-service
   subsets:
     - name: v1
       labels:

--- a/helm/restaurant-sentiment/templates/model-service-virtualservice.yaml
+++ b/helm/restaurant-sentiment/templates/model-service-virtualservice.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: model-service
+spec:
+  hosts:
+    - model-service
+  http:
+    - match:
+        - headers:
+            x-user-id:
+              exact: "test-user"
+      route:
+        - destination:
+            host: model-service
+            subset: v2
+          weight: 100
+    - route:
+        - destination:
+            host: model-service
+            subset: v1
+          weight: 90
+        - destination:
+            host: model-service
+            subset: v2
+          weight: 10


### PR DESCRIPTION
Description:
This pull request adds Istio traffic routing resources to support Assignment A5.

What’s included:
	•	A VirtualService for model-service that routes 100% of traffic to version v2 when the x-user-id header is set to “test-user”. All other traffic is split: 90% to v1 and 10% to v2.
	•	A DestinationRule that defines version subsets based on pod labels.
	•	The resources are templated under the Helm chart at templates/model-service-virtualservice.yaml and templates/model-service-destinationrule.yaml.
	•	Confirmed the routing works as expected by checking resource creation with kubectl and testing app behavior via port-forward.

This implementation completes the Istio-based traffic management component of Assignment A5.